### PR TITLE
adds dag to trigger multiprocessing dag

### DIFF
--- a/dags/pipeline_small_multiprocessing.py
+++ b/dags/pipeline_small_multiprocessing.py
@@ -120,11 +120,12 @@ with DAG(
             task_id=f"trigger_dependent_dag_{x}",
             trigger_dag_id=DAG_ID,
             wait_for_completion=True,
+            # creates (4) DAGRuns for the triggered DAG at 2 hour intervals from (and including) the current DAG's start time
+            # data_interval_end is the moment at which the DAG is scheduled to start _in UTC_, i.e., 21:00 CE(S)T, converted to UTC
             execution_date=f"{{{{ data_interval_end.in_tz('Europe/Amsterdam').add(hours={x} * 2) }}}}",  # data_interval_end is in UTC
-            conf={"date": f"{{{{ data_interval_end.to_date_string() ~ ' 21:{x}0:00' }}}}"},
+            conf={"date": f"{{{{ data_interval_end.in_tz('Europe/Amsterdam').to_date_string() ~ ' 21:{x}0:00' }}}}"},
         )
         for x in range(4)]
-    trigs
 
 with DAG(
         DAG_ID,

--- a/dags/pipeline_small_multiprocessing.py
+++ b/dags/pipeline_small_multiprocessing.py
@@ -111,7 +111,7 @@ with DAG(
         "trigger-multiprocessing-small",
         start_date=datetime(2023, 1, 10),
         max_active_runs=1,
-        schedule_interval="0 21 * * 3",  # Every Wednesday at 21:00 CEST
+        schedule_interval="0 21 * * 3",  # Every Wednesday at 21:00 CE(S)T
         default_args=default_args,
         catchup=False
 ) as dag:

--- a/dags/pipeline_small_multiprocessing.py
+++ b/dags/pipeline_small_multiprocessing.py
@@ -111,7 +111,7 @@ with DAG(
         "trigger-multiprocessing-small",
         start_date=datetime(2023, 1, 10),
         max_active_runs=1,
-        schedule_interval="0 21 * * 3",  # Every Wednesday at 21:00 CE(S)T
+        schedule_interval="0 20 * * 3",  # Will start every Wednesday at 21:00 CE(S)T
         default_args=default_args,
         catchup=False
 ) as dag:
@@ -123,7 +123,7 @@ with DAG(
             # creates (4) DAGRuns for the triggered DAG at 2 hour intervals from (and including) the current DAG's start time
             # data_interval_end is the moment at which the DAG is scheduled to start _in UTC_, i.e., 21:00 CE(S)T, converted to UTC
             execution_date=f"{{{{ data_interval_end.in_tz('Europe/Amsterdam').add(hours={x} * 2) }}}}",  # data_interval_end is in UTC
-            conf={"date": f"{{{{ data_interval_end.in_tz('Europe/Amsterdam').to_date_string() ~ ' 21:{x}0:00' }}}}"},
+            conf={"date": f"{{{{ data_interval_end.in_tz('Europe/Amsterdam').to_date_string() ~ ' 21:{x}0:00.00' }}}}"},
         )
         for x in range(4)]
 

--- a/dags/pipeline_small_multiprocessing.py
+++ b/dags/pipeline_small_multiprocessing.py
@@ -111,7 +111,7 @@ with DAG(
         "trigger-multiprocessing-small",
         start_date=datetime(2023, 1, 10),
         max_active_runs=1,
-        schedule_interval="0 20 * * 3",  # Will start every Wednesday at 21:00 CE(S)T
+        schedule_interval="0 20 * * 3",  # 20:00 UTC, will start every Wednesday at 21:00 CET
         default_args=default_args,
         catchup=False
 ) as dag:
@@ -121,7 +121,7 @@ with DAG(
             trigger_dag_id=DAG_ID,
             wait_for_completion=True,
             # creates (4) DAGRuns for the triggered DAG at 2 hour intervals from (and including) the current DAG's start time
-            # data_interval_end is the moment at which the DAG is scheduled to start _in UTC_, i.e., 21:00 CE(S)T, converted to UTC
+            # data_interval_end is the moment at which the DAG is scheduled to start in UTC, i.e., 21:00 CET, converted to UTC
             execution_date=f"{{{{ data_interval_end.in_tz('Europe/Amsterdam').add(hours={x} * 2) }}}}",  # data_interval_end is in UTC
             conf={"date": f"{{{{ data_interval_end.in_tz('Europe/Amsterdam').to_date_string() ~ ' 21:{x}0:00.00' }}}}"},
         )


### PR DESCRIPTION
DAG to trigger multiprocessing DAG. Some TZ conversion :grimacing: to work around the fact that `schedule_interval` uses server time (CE(S)T), while Airflow internals use UTC.